### PR TITLE
Fixed opengraph image

### DIFF
--- a/app/_lib/og-image.tsx
+++ b/app/_lib/og-image.tsx
@@ -12,11 +12,17 @@ export const getBaseURL = () => {
   return "http://localhost:3000";
 };
 
-export const getOgImage = (
-  title: string,
-  subtitle: string,
-  content?: string,
-) => {
+export const getOgImage = ({
+  title,
+  subtitle,
+  pathname,
+  content,
+}: {
+  title: string;
+  subtitle: string;
+  pathname: string;
+  content?: string;
+}) => {
   return new ImageResponse(
     (
       <div tw="relative flex h-full w-full flex-col bg-zinc-900 p-8">
@@ -26,16 +32,9 @@ export const getOgImage = (
 
         {!!content && <h3 tw="my-0 text-4xl text-zinc-400">{content}</h3>}
 
-        <p tw="mt-auto mb-0 text-3xl text-green-500">akhilaariyachandra.com</p>
-
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={`${getBaseURL()}/profile-pic.jpg`}
-          alt="Akhila Ariyachandra"
-          width={240}
-          height={240}
-          tw="absolute right-8 bottom-8 rounded-xl"
-        />
+        <p tw="mt-auto mb-0 text-3xl text-green-500">
+          akhilaariyachandra.com{pathname}
+        </p>
       </div>
     ),
     {

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -24,11 +24,12 @@ const Image = async (props: PageProps<"/blog/[slug]">) => {
     notFound();
   }
 
-  return getOgImage(
-    post.title,
-    "Akhila Ariyachandra",
-    dayjs(post.posted).format("Do MMMM YYYY"),
-  );
+  return getOgImage({
+    title: post.title,
+    subtitle: "Akhila Ariyachandra",
+    pathname: `/blog/${params.slug}`,
+    content: dayjs(post.posted).format("Do MMMM YYYY"),
+  });
 };
 
 export default Image;

--- a/app/blog/opengraph-image.tsx
+++ b/app/blog/opengraph-image.tsx
@@ -11,7 +11,11 @@ export const contentType = "image/png";
 
 // Image generation
 const Image = () => {
-  return getOgImage("Personal Blog", "Akhila Ariyachandra");
+  return getOgImage({
+    title: "Personal Blog",
+    subtitle: "Akhila Ariyachandra",
+    pathname: "/blog",
+  });
 };
 
 export default Image;

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -11,7 +11,11 @@ export const contentType = "image/png";
 
 // Image generation
 const Image = () => {
-  return getOgImage("Akhila Ariyachandra", "Web Developer");
+  return getOgImage({
+    title: "Akhila Ariyachandra",
+    subtitle: "Web Developer",
+    pathname: "",
+  });
 };
 
 export default Image;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors OG image utility to accept an options object (incl. pathname) and updates OG endpoints to render domain + path and pass post date where applicable.
> 
> - **Open Graph image generation**:
>   - **API refactor**: `getOgImage` now accepts an options object `{ title, subtitle, pathname, content? }` instead of positional args.
>   - **Rendering change**: removes profile image and static footer; adds `akhilaariyachandra.com{pathname}` footer.
>   - **Consumers updated**:
>     - `app/blog/[slug]/opengraph-image.tsx`: passes `pathname` (`/blog/{slug}`) and `content` (formatted post date).
>     - `app/blog/opengraph-image.tsx`: passes `pathname` (`/blog`).
>     - `app/opengraph-image.tsx`: passes empty `pathname` for root.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18ce040e5569fa2b4f78cec434854b0d7a7f3a5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->