### PR TITLE
Revert "Fixed opengraph image"

### DIFF
--- a/app/_lib/og-image.tsx
+++ b/app/_lib/og-image.tsx
@@ -12,17 +12,11 @@ export const getBaseURL = () => {
   return "http://localhost:3000";
 };
 
-export const getOgImage = ({
-  title,
-  subtitle,
-  pathname,
-  content,
-}: {
-  title: string;
-  subtitle: string;
-  pathname: string;
-  content?: string;
-}) => {
+export const getOgImage = (
+  title: string,
+  subtitle: string,
+  content?: string,
+) => {
   return new ImageResponse(
     (
       <div tw="relative flex h-full w-full flex-col bg-zinc-900 p-8">
@@ -32,9 +26,16 @@ export const getOgImage = ({
 
         {!!content && <h3 tw="my-0 text-4xl text-zinc-400">{content}</h3>}
 
-        <p tw="mt-auto mb-0 text-3xl text-green-500">
-          akhilaariyachandra.com{pathname}
-        </p>
+        <p tw="mt-auto mb-0 text-3xl text-green-500">akhilaariyachandra.com</p>
+
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`${getBaseURL()}/profile-pic.jpg`}
+          alt="Akhila Ariyachandra"
+          width={240}
+          height={240}
+          tw="absolute right-8 bottom-8 rounded-xl"
+        />
       </div>
     ),
     {

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -24,12 +24,11 @@ const Image = async (props: PageProps<"/blog/[slug]">) => {
     notFound();
   }
 
-  return getOgImage({
-    title: post.title,
-    subtitle: "Akhila Ariyachandra",
-    pathname: `/blog/${params.slug}`,
-    content: dayjs(post.posted).format("Do MMMM YYYY"),
-  });
+  return getOgImage(
+    post.title,
+    "Akhila Ariyachandra",
+    dayjs(post.posted).format("Do MMMM YYYY"),
+  );
 };
 
 export default Image;

--- a/app/blog/opengraph-image.tsx
+++ b/app/blog/opengraph-image.tsx
@@ -11,11 +11,7 @@ export const contentType = "image/png";
 
 // Image generation
 const Image = () => {
-  return getOgImage({
-    title: "Personal Blog",
-    subtitle: "Akhila Ariyachandra",
-    pathname: "/blog",
-  });
+  return getOgImage("Personal Blog", "Akhila Ariyachandra");
 };
 
 export default Image;

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -11,11 +11,7 @@ export const contentType = "image/png";
 
 // Image generation
 const Image = () => {
-  return getOgImage({
-    title: "Akhila Ariyachandra",
-    subtitle: "Web Developer",
-    pathname: "",
-  });
+  return getOgImage("Akhila Ariyachandra", "Web Developer");
 };
 
 export default Image;


### PR DESCRIPTION
This reverts commit a77bb18275b4c6beee82dfbbb2c2c6651f62e351.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors OG image generator to use positional args, drop pathname, add a profile picture, and updates all OG image routes accordingly.
> 
> - **OG Image Generation**:
>   - Refactor `getOgImage` in `app/_lib/og-image.tsx` to accept `(title, subtitle, content?)` positional args (replacing object param) and remove `pathname` support.
>   - Always render site domain text without path and add a profile image sourced via `getBaseURL()`.
> - **Call Site Updates**:
>   - Update `app/blog/[slug]/opengraph-image.tsx`, `app/blog/opengraph-image.tsx`, and `app/opengraph-image.tsx` to use new `getOgImage` signature; post page passes formatted date as content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f051a49103afe47c26f9df6a6569079f8b20db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->