### PR TITLE
Fixed missing `async`/`await`

### DIFF
--- a/app/_components/views.tsx
+++ b/app/_components/views.tsx
@@ -23,8 +23,8 @@ type ViewsProps = {
   increment?: boolean;
 };
 
-const Views = ({ slug, increment = false }: ViewsProps) => {
-  const views = getViews(slug);
+const Views = async ({ slug, increment = false }: ViewsProps) => {
+  const views = await getViews(slug);
 
   return (
     <>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert `Views` component to `async` and await `getViews` to correctly fetch and display view counts.
> 
> - **Components**:
>   - Update `app/_components/views.tsx`:
>     - Make `Views` component `async` and `await getViews(slug)` to fetch view count before render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef333ad5a04da8798b60029064b7c76635a42f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->